### PR TITLE
manual.lisp: Remove redundant "of"

### DIFF
--- a/source/manual.lisp
+++ b/source/manual.lisp
@@ -122,7 +122,7 @@ documentation.")
     (:p "Creating your own invokable commands is similar to creating a Common
 Lisp function, except the form is " (:code "define-command") " instead of "
         (:code "defun") ". If you want this command to be invokable outside of
-        the context of of a mode, use " (:code "define-command-global") ".")
+        the context of a mode, use " (:code "define-command-global") ".")
     (:p "Example:")
     (:pre (:code
            "(define-command-global bookmark-url ()


### PR DESCRIPTION
This removes a redundant 'of' in the 'Custom commands' section of the manual.